### PR TITLE
bug: fix error when jwt_secret is not set

### DIFF
--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -20,7 +20,7 @@ class ApiSettings(BaseSettings):
 
     lower_case_query_parameters: bool = False
     fake_https: bool = False
-    jwt_secret: str = None
+    jwt_secret: str = ""
 
     model_config = SettingsConfigDict(env_prefix="TITILER_API_", env_file=".env")
 


### PR DESCRIPTION
jwt_secret 이 설정되어 있지 않은 경우 에러가 발생하는 현상을 수정했습니다.
jwt_secret 을 설정하지 않을 경우에는 기본적으로 jwt 를 검사하지 않습니다.